### PR TITLE
Added support for automatic insurance allocation

### DIFF
--- a/R/insurance_purchase_forage.R
+++ b/R/insurance_purchase_forage.R
@@ -107,7 +107,7 @@ wt_alloc_scaled
 
 # Final insurance purchase input 
 cbind(wt_iv,round(wt_alloc,2))
-cbind(wt_iv,round(round(wt_alloc,2))) # with more generalized rounding
+cbind(wt_iv,round(wt_alloc_scaled,2)) # scaled for max allocation
 
 
 ##OPTION 2 - HIGHEST WEIGHTED INTERVAL SETS##
@@ -122,13 +122,27 @@ cbind(wt_iv,round(round(wt_alloc,2))) # with more generalized rounding
 # which are both highly weighted, but not quite as high 
 # as the interval they bound (Jun-July).
 
-niv=2 # number of intervals to insure 
+niv=3 # number of intervals to insure 
 
 # Separate intervals 
 # this ensures no overlap
-odd_int=seq(1,11,by=2)
-even_int=seq(2,10,by=2)
+odd_iv=seq(1,11,by=2)
+even_iv=seq(2,10,by=2)
 
+# All combos of intervals
+iv_comb=cbind(combn(odd_iv,niv),combn(even_iv,niv))
 
+# Mean of weights for interval combos
+combwt=c()
+for(i in 1:ncol(iv_comb)){
+  
+  combwt=c(combwt,
+           (sum(fpwt_iv[iv_comb[,i]])/2))
+  
+}
 
-
+# Select best intervals
+# with 3 chosen this is identical to option 1
+wt_iv=iv_comb[,which.max(combwt)]
+wt_choice=fpwt_iv[wt_iv]
+cat(wt_iv,wt_choice,sep="\n")

--- a/R/insurance_purchase_forage.R
+++ b/R/insurance_purchase_forage.R
@@ -172,6 +172,20 @@ forageWeights2Intervals<-function(fpwt){
   
 }
 
+rescaleInsAlloc<-function(wt_choice,max.alloc){
+  
+  "
+  Helper function for rescaling insurance
+  allocation percentages by a maximum 
+  allocation percentage. 
+  "
+  
+  wt_scl=wt_choice
+  wt_scl[1]=max.alloc
+  wt_scl[2:length(wt_scl)]=(wt_scl[2:length(wt_scl)]/sum(wt_scl[2:length(wt_scl)]))*(1-max.alloc)
+  return(wt_scl)
+}
+
 ## Option 1 - By Rank
 insuranceSelect_opt1<-function(fpwt,niv=2){
   
@@ -206,10 +220,10 @@ insuranceSelect_opt1<-function(fpwt,niv=2){
 }
 
 insuranceSelect_opt1(fpwt,2) # seems to work
-
+ins_opt1=insuranceSelect_opt1(fpwt,3) # repeating worked example
 
 ## Option 2 - By Combo
-insuranceSelect_opt2<-function(fpwt,niv=2){
+insuranceSelect_opt2<-function(fpwt,niv=2,max.alloc=NULL){
   
   fpwt_iv=forageWeights2Intervals(fpwt) # bin forage potential weights into intervals
   
@@ -233,9 +247,23 @@ insuranceSelect_opt2<-function(fpwt,niv=2){
   # Select best intervals
   wt_iv=iv_comb[,which.max(combwt)]
   wt_choice=fpwt_iv[wt_iv]
+  wt_out=cbind(wt_iv,wt_choice) # convert to matrix
+  wt_out=wt_out[order(-wt_out[,2]),] # sort descending
   
-  return(cbind(wt_iv,wt_choice))
+  # Set max allocation percentages if existing max is too high
+  if(max(wt_out[,2]>0.6) & is.null(max.alloc)){
+      max.alloc=0.6 # set max.alloc to highest possible allocation pct
+  }  
+
+  # rescale allocation percentages if a maximum allocation is set
+  if(!is.null(max.alloc)){
+    wt_out[,2]=rescaleInsAlloc(wt_out[,2],max.alloc)
+  }
+  
+  return(wt_out)
   
 }
 
-insuranceSelect_opt2(fpwt,2) # seems to work
+insuranceSelect_opt2(fpwt,3) # seems to work
+ins_opt2=insuranceSelect_opt2(fpwt,3) # repeating worked example
+

--- a/R/support_functions.R
+++ b/R/support_functions.R
@@ -944,3 +944,113 @@ COOP_in_MRLA<-function(coop){
   return(as.numeric(as.character(((coop.pt %over% mlra)$MLRARSYM))))
   
 }
+
+forageWeights2Intervals<-function(fpwt){
+  
+  "
+  Helper function for binning monthly 
+  forage weights into 2-month intervals
+  matching the RMA insurance. 
+  "
+  
+  fpwt_iv=c()
+  for(m in 1:11){
+    
+    fpwt_iv=c(fpwt_iv,(sum(fpwt[m],fpwt[m+1])/2)) # need to calc mean manually - not sure why
+    names(fpwt_iv[m])=paste0("i",m)
+    
+  }
+  
+  return(fpwt_iv)
+  
+}
+
+rescaleInsAlloc<-function(wt_choice,max.alloc){
+  
+  "
+  Helper function for rescaling insurance
+  allocation percentages by a maximum 
+  allocation percentage. 
+  "
+  
+  wt_scl=wt_choice
+  wt_scl[1]=max.alloc
+  wt_scl[2:length(wt_scl)]=(wt_scl[2:length(wt_scl)]/sum(wt_scl[2:length(wt_scl)]))*(1-max.alloc)
+  return(wt_scl)
+}
+
+insAlloc<-function(fpwt,niv=2,by.rank=T,max.alloc=NULL){
+  
+  if(by.rank){
+  
+    fpwt_iv=forageWeights2Intervals(fpwt) # bin forage potential weights into intervals
+    fpwt_iv_rank=rank(-fpwt_iv) # rank interval weights descending
+    names(fpwt_iv_rank)=paste0("i",1:11)
+    top_iv=which.min(fpwt_iv_rank) # index of top-ranked interval
+    
+    wt_iv=top_iv
+    cand_iv=fpwt_iv_rank[-c((top_iv-1):(top_iv+1))] # candidate secondary intervals
+    
+    for(i in 2:niv){
+      
+      excl_iv=unique(unlist(lapply(wt_iv,function(X)-1:1+X))) #intervals to exclude (prev. chosen/overlapping)
+      cand_iv=fpwt_iv_rank[-excl_iv]
+      
+      # Append the highest-ranked choice to 'wt_iv'
+      if(length(cand_iv)>0){
+        iv_select=names(cand_iv[which.min(cand_iv)]) # get top-ranked candidate weight
+        iv_select=as.numeric(substr(iv_select,2,nchar(iv_select))) # get original index from interval name
+        wt_iv=c(wt_iv,iv_select)
+      }else{ # end if no choices left
+        break
+      }
+      
+    }
+    
+  }else{ #use max combination of weights / number of intervals specified
+    
+    # Separate intervals 
+    # this ensures no overlap
+    odd_iv=seq(1,11,by=2)
+    even_iv=seq(2,10,by=2)
+    
+    # All combos of intervals
+    iv_comb=cbind(combn(odd_iv,niv),combn(even_iv,niv))
+    
+    # Mean of weights for interval combos
+    combwt=c()
+    for(i in 1:ncol(iv_comb)){
+      
+      combwt=c(combwt,
+               (sum(fpwt_iv[iv_comb[,i]])/2))
+      
+    }
+    
+    # Select best intervals
+    wt_iv=iv_comb[,which.max(combwt)]
+    
+    
+  }
+  
+  wt_choice=fpwt_iv[wt_iv] # get weight values
+  wt_out=cbind(wt_iv,wt_choice) # convert to matrix
+  wt_out=wt_out[order(-wt_out[,2]),] # sort descending
+  
+  # Set max allocation percentages if existing max is too high
+  if(max(wt_out[,2]>0.6) & is.null(max.alloc)){
+    max.alloc=0.6 # set max.alloc to highest possible allocation pct
+  }  
+  
+  # rescale allocation percentages if a maximum allocation is set
+  if(!is.null(max.alloc)){
+    wt_out[,2]=rescaleInsAlloc(wt_out[,2],max.alloc)
+  }
+  
+  # Round allocation pcts to 2 signif. digits
+  # since PRF decision model only runs on 
+  # whole number allocation pcts 
+  wt_out[,2]=round(wt_out[,2],2)
+
+  return(wt_out)
+
+}

--- a/R/support_functions.R
+++ b/R/support_functions.R
@@ -1029,9 +1029,53 @@ rescaleInsAlloc<-function(alloc_choice,max.alloc=0.6,min.alloc=0.1){
 
 insAlloc<-function(fpwt,niv=2,by.rank=T,max.alloc=0.6,min.alloc=0.1){
   
+  "
+  Automates range insurance allocation to two-month
+  RMA intervals using a grid cell/COOP site's forage
+  potential weights. Returns a matrix formatted as the
+  `insPurchase` input for function `insMat`.
+
+  Allocation for chosen two-month intervals is roughly
+  proportional to the relative value of each interval's 
+  forage potential weight. Adjustments to allocation 
+  percentages are automatically made if a selection is invalid
+  for one or more intervals, either too high (>60%) or too low 
+  (10%).
+  User-specified min/max allocation percentages falling within
+  this range may also be substituted by setting the `max.alloc`
+  and `min.alloc` arguments.
+
+
+  Inputs:  
+
+    `fpwt`: A vector of monthly forage potential weights
+      for the target site. Monthly intervals are averaged
+      to two-month intervals to match RMA insurance
+      selections.
+
+    `niv`: Number of two-month intervals to insure.
+  
+    `by.rank`: if TRUE (default), ranks forage potential
+      weights by interval in descending order and selects
+      the `niv` most highly ranked non-consecutive intervals
+      to insure. 
+
+      If FALSE, selects the combination of `niv` non-
+      consecutive two-month intervals with the highest 
+      average forage potential weights.
+
+    `max.alloc`: Maximum insurance protection allocation. Must
+      not exceed 0.6.
+
+    `min.alloc`: Minimum insurance protection allocation. Must
+      be at least 0.1.
+
+  "
+  
+  fpwt_iv=forageWeights2Intervals(fpwt) # bin forage potential weights into intervals
+  
   if(by.rank){
   
-    fpwt_iv=forageWeights2Intervals(fpwt) # bin forage potential weights into intervals
     fpwt_iv_rank=rank(-fpwt_iv) # rank interval weights descending
     names(fpwt_iv_rank)=paste0("i",1:11)
     top_iv=which.min(fpwt_iv_rank) # index of top-ranked interval

--- a/R/vars.R
+++ b/R/vars.R
@@ -104,8 +104,17 @@ yyr=2002:2006 # all five years
 clv=0.9 # insurance coverage level (0.7 - 0.9 in increments of 0.05)
 acres=3000 # ranch acres
 pfactor=1 # productivity factor (0.6 - 1.5)
-insp=rbind(c(3,0.5),c(5,0.5)) # insurance purchase
 
+# Insurance purchases
+# Use Excel model choices by default,
+# otherwise automatically allocate based
+# upon forage potential
+if(!exists("autoSelect.insurance")){
+  insp=rbind(c(3,0.5),c(5,0.5)) # insurance purchase
+}else{
+  insp=insAlloc(fpwt=zonewt[stzone,],niv=2) # automatic selection
+}
+  
 # SpatialPoints representation of target gridcell 
 # for fetching insurance results
 tgrd_pt = rastPt[rastPt@data$layer == tgrd, ]  

--- a/master.R
+++ b/master.R
@@ -13,8 +13,8 @@
 #   ...
 
 # Clear environment
-# prevent from erasing custom location if set
-rm(list=ls()[ls()!="target.loc"])
+# prevent from erasing custom location/insurance selection if set
+rm(list=ls()[!ls() %in% c("target.loc","autoSelect.insurance")])
 
 # Source functions
 source("R/support_functions.R")


### PR DESCRIPTION
The model now supports automatic insurance allocation based on site-specific forage potential weights. This is enabled by creating a variable `autoSelect.insurance` prior to running the model (value doesn't matter right now - its existence enables the switch). 